### PR TITLE
fix: multiple on success and error callbacks with loadingStatusRef prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,14 +121,14 @@
     "@redux-saga/core": "1.0.3",
     "@rjsf/core": "^2.5.1",
     "debug": "4.3.1",
-    "immer": ">=3.0.0",
+    "immer": ">=9.0.0",
     "phoenix": "~1.5.9",
     "prop-types": "^15.7.2",
     "react": ">=16.8.6",
     "react-dom": ">=16.8.0",
     "react-redux": ">=7.2.1",
-    "redux": ">=4.0.1",
-    "redux-saga": "1.0.5",
+    "redux": "~4.1.2",
+    "redux-saga": ">=1.1.0",
     "reselect": "~4.0.0"
   },
   "dependencies": {

--- a/src/React/hooks/use-trixta-action/types.ts
+++ b/src/React/hooks/use-trixta-action/types.ts
@@ -22,6 +22,10 @@ export interface UseTrixtaActionProps<
      * Submit to trixta action when component mounts
      */
     autoSubmit?: boolean;
+    /**
+     * If 'true', will clear all responses when onSuccess or onError callbacks are called
+     */
+    clearResponsesOnCallback?: boolean;
   };
   /**
    * Parameters to submit to Trixta for autoSubmit

--- a/src/React/hooks/use-trixta-reaction/types.ts
+++ b/src/React/hooks/use-trixta-reaction/types.ts
@@ -23,6 +23,10 @@ export interface UseTrixtaReactionProps<
    * This function will fire if the response from Trixta encounters an error and will be passed the error.
    */
   onError?: (error?: TErrorType) => void;
+  /**
+   * If 'true', will clear all responses when onSuccess or onError callbacks are called
+   */
+  clearResponsesOnCallback?: boolean;
 }
 
 export interface UseTrixtaReactionHookReturn<

--- a/src/React/reducers/__tests__/reducers.test.ts
+++ b/src/React/reducers/__tests__/reducers.test.ts
@@ -5,15 +5,20 @@ import {
   getMessageFromError,
   getReactionDetails,
   getReducerKeyName,
-  getRequestStatusKeyName, getTrixtaActionReducerStructure, getTrixtaActionResponseInstanceResult, getTrixtaReactionInstanceResult,
-  getTrixtaReactionReducerStructure, getTrixtaReactionResponseInstanceResult, isObject,
-  pickBy
+  getRequestStatusKeyName,
+  getTrixtaActionReducerStructure,
+  getTrixtaActionResponseInstanceResult,
+  getTrixtaReactionInstanceResult,
+  getTrixtaReactionReducerStructure,
+  getTrixtaReactionResponseInstanceResult,
+  isObject,
+  pickBy,
 } from '../../../utils';
 import {
   SUBMIT_TRIXTA_ACTION_RESPONSE_FAILURE,
   SUBMIT_TRIXTA_ACTION_RESPONSE_SUCCESS,
   SUBMIT_TRIXTA_REACTION_RESPONSE_FAILURE,
-  SUBMIT_TRIXTA_REACTION_RESPONSE_SUCCESS
+  SUBMIT_TRIXTA_REACTION_RESPONSE_SUCCESS,
 } from '../../constants';
 import * as actions from '../../reduxActions';
 import { signoutTrixta } from '../../reduxActions';
@@ -22,7 +27,7 @@ import {
   RequestStatus,
   TrixtaInstanceMode,
   TrixtaRoleParameter,
-  TrixtaState
+  TrixtaState,
 } from '../../types/common';
 import { initialState, trixtaReducer } from '../trixtaReducer';
 // eslint-disable-next-line jest/no-mocks-import


### PR DESCRIPTION
fix: multiple on success and error callbacks with loadingStatusRef prop

### What:

<!-- What changes are being made? What feature/bug is being fixed here? (#WR-) -->

### How:

<!-- How were these changes implemented? -->

### Comments:

<!-- feel free to add additional comments -->
