### PR TITLE
fix: use correct types for onError and onSuccess callbacks for hooks

### DIFF
--- a/src/React/hooks/use-trixta-action-reaction/use-trixta-action-reaction.ts
+++ b/src/React/hooks/use-trixta-action-reaction/use-trixta-action-reaction.ts
@@ -15,19 +15,19 @@ export const useTrixtaActionReaction = <
   /**
    * Type for response from Trixta action
    */
-  TActionResponseType = DefaultUnknownType,
+  TActionResponseType,
   /**
    * Type for error response from Trixta action
    */
-  TActionErrorType = DefaultUnknownType,
+  TActionErrorType,
   /**
    * Type for response from Trixta reaction
    */
-  TReactionResponseType = DefaultUnknownType,
+  TReactionResponseType,
   /**
    * Type for error response from Trixta reaction
    */
-  TReactionErrorType = DefaultUnknownType
+  TReactionErrorType
 >({
   actionProps,
   reactionProps,

--- a/src/React/hooks/use-trixta-action/types.ts
+++ b/src/React/hooks/use-trixta-action/types.ts
@@ -34,11 +34,11 @@ export interface UseTrixtaActionProps<
   /**
    * This function will fire any time the response from Trixta successfully returns data and will be passed the data.
    */
-  onSuccess?: (success?: TSuccessType) => void;
+  onSuccess?: (success: TSuccessType) => void;
   /**
    * This function will fire if the response from Trixta encounters an error and will be passed the error.
    */
-  onError?: (error?: TErrorType) => void;
+  onError?: (error: TErrorType) => void;
 }
 
 export interface UseTrixtaActionHookReturn<

--- a/src/React/hooks/use-trixta-action/use-trixta-action.ts
+++ b/src/React/hooks/use-trixta-action/use-trixta-action.ts
@@ -18,7 +18,6 @@ import {
   trixtaInstanceDebugger,
 } from '../../TrixtaDebugger';
 import {
-  DefaultUnknownType,
   RequestStatus,
   SubmitTrixtaFunctionParameters,
   TrixtaActionBaseProps,
@@ -31,11 +30,11 @@ export const useTrixtaAction = <
   /**
    * Type for response from Trixta
    */
-  TResponseType = DefaultUnknownType,
+  TResponseType,
   /**
    * Type for error response from Trixta
    */
-  TErrorType = DefaultUnknownType
+  TErrorType
 >({
   roleName,
   actionName,
@@ -49,10 +48,10 @@ export const useTrixtaAction = <
   },
   onSuccess,
   onError,
-}: UseTrixtaActionProps<
-  TResponseType | unknown,
-  TErrorType | unknown
->): UseTrixtaActionHookReturn<TResponseType, TErrorType> => {
+}: UseTrixtaActionProps<TResponseType, TErrorType>): UseTrixtaActionHookReturn<
+  TResponseType,
+  TErrorType
+> => {
   const dispatch = useDispatch();
   const latestTimeStamp = useRef<number | undefined>(undefined);
   const currentLoadingStatusRef = useRef<string | undefined>(undefined);
@@ -206,7 +205,7 @@ export const useTrixtaAction = <
       ) {
         latestTimeStamp.current = instanceTimeStamp;
         currentLoadingStatusRef.current = undefined;
-        if (onSuccess) {
+        if (onSuccess && success) {
           onSuccess(success);
           if (options.clearResponsesOnCallback) clearActionResponses();
         }
@@ -221,7 +220,7 @@ export const useTrixtaAction = <
       ) {
         latestTimeStamp.current = instanceTimeStamp;
         currentLoadingStatusRef.current = undefined;
-        if (onError) {
+        if (onError && error) {
           onError(error);
           if (options.clearResponsesOnCallback) clearActionResponses();
         }

--- a/src/React/hooks/use-trixta-reaction/types.ts
+++ b/src/React/hooks/use-trixta-reaction/types.ts
@@ -18,11 +18,11 @@ export interface UseTrixtaReactionProps<
    * If 'true', will set the timeoutEvent the same as the ErrorEvent
    */
   setTimeoutEventAsErrorEvent?: boolean;
-  onSuccess?: (success?: TSuccessType) => void;
+  onSuccess?: (success: TSuccessType) => void;
   /**
    * This function will fire if the response from Trixta encounters an error and will be passed the error.
    */
-  onError?: (error?: TErrorType) => void;
+  onError?: (error: TErrorType) => void;
   /**
    * If 'true', will clear all responses when onSuccess or onError callbacks are called
    */

--- a/src/React/hooks/use-trixta-reaction/use-trixta-reaction.ts
+++ b/src/React/hooks/use-trixta-reaction/use-trixta-reaction.ts
@@ -31,15 +31,15 @@ export const useTrixtaReaction = <
   /**
    * Type for initial data from Trixta Reaction
    */
-  TInitialData = DefaultUnknownType,
+  TInitialData,
   /**
    * Type for response from Trixta
    */
-  TResponseType = DefaultUnknownType,
+  TResponseType,
   /**
    * Type for error response from Trixta
    */
-  TErrorType = DefaultUnknownType
+  TErrorType
 >({
   roleName,
   reactionName,
@@ -190,7 +190,7 @@ export const useTrixtaReaction = <
       ) {
         latestTimeStamp.current = instanceTimeStamp;
         currentLoadingStatusRef.current = undefined;
-        if (onSuccess) {
+        if (onSuccess && success) {
           onSuccess(success);
           if (clearResponsesOnCallback) clearReactionResponses();
         }
@@ -205,7 +205,7 @@ export const useTrixtaReaction = <
       ) {
         latestTimeStamp.current = instanceTimeStamp;
         currentLoadingStatusRef.current = undefined;
-        if (onError) {
+        if (onError && error) {
           onError(error);
           if (clearResponsesOnCallback) clearReactionResponses();
         }

--- a/src/React/reduxActions/internal/actions/types.ts
+++ b/src/React/reduxActions/internal/actions/types.ts
@@ -5,38 +5,30 @@ import {
 } from '../../../constants';
 import { AdditionalTrixtaData } from '../types';
 
+export type AdditionalActionTrixtaDataType = {
+  extraData?: Record<string, unknown>;
+  trixtaMeta: AdditionalTrixtaData & {
+    actionName: string;
+  };
+};
+
 export type SubmitTrixtaActionResponseSuccessAction = {
   type: typeof SUBMIT_TRIXTA_ACTION_RESPONSE_SUCCESS;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   data: any;
-  additionalData: {
-    extraData?: Record<string, unknown>;
-    trixtaMeta: AdditionalTrixtaData & {
-      actionName: string;
-    };
-  };
+  additionalData: AdditionalActionTrixtaDataType;
 };
 
 export type SubmitTrixtaActionResponseFailureAction = {
   type: typeof SUBMIT_TRIXTA_ACTION_RESPONSE_FAILURE;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   error: any;
-  additionalData: {
-    extraData?: Record<string, unknown>;
-    trixtaMeta: AdditionalTrixtaData & {
-      actionName: string;
-    };
-  };
+  additionalData: AdditionalActionTrixtaDataType;
 };
 
 export type SubmitTrixtaActionResponseTimeoutFailureAction = {
   type: typeof SUBMIT_TRIXTA_ACTION_TIMEOUT_RESPONSE_FAILURE;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   error: any;
-  additionalData: {
-    extraData?: Record<string, unknown>;
-    trixtaMeta: AdditionalTrixtaData & {
-      actionName: string;
-    };
-  };
+  additionalData: AdditionalActionTrixtaDataType;
 };

--- a/src/React/reduxActions/internal/reactions/types.ts
+++ b/src/React/reduxActions/internal/reactions/types.ts
@@ -5,41 +5,31 @@ import {
 } from '../../../constants';
 import { AdditionalTrixtaData } from '../types';
 
+export type AdditionalReactionTrixtaDataType = {
+  extraData?: Record<string, unknown>;
+  trixtaMeta: AdditionalTrixtaData & {
+    reactionName: string;
+    ref?: string;
+  };
+};
+
 export type SubmitTrixtaReactionResponseFailureAction = {
   type: typeof SUBMIT_TRIXTA_REACTION_RESPONSE_FAILURE;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   error: any;
-  additionalData: {
-    extraData?: Record<string, unknown>;
-    trixtaMeta: AdditionalTrixtaData & {
-      ref?: string;
-      reactionName: string;
-    };
-  };
+  additionalData: AdditionalReactionTrixtaDataType;
 };
 
 export type SubmitTrixtaReactionResponseTimeoutFailureAction = {
   type: typeof SUBMIT_TRIXTA_REACTION_TIMEOUT_RESPONSE_FAILURE;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   error: any;
-  additionalData: {
-    extraData?: Record<string, unknown>;
-    trixtaMeta: AdditionalTrixtaData & {
-      ref?: string;
-      reactionName: string;
-    };
-  };
+  additionalData: AdditionalReactionTrixtaDataType;
 };
 
 export type SubmitTrixtaReactionResponseSuccessAction = {
   type: typeof SUBMIT_TRIXTA_REACTION_RESPONSE_SUCCESS;
-  additionalData: {
-    extraData?: Record<string, unknown>;
-    trixtaMeta: AdditionalTrixtaData & {
-      ref?: string;
-      reactionName: string;
-    };
-  };
+  additionalData: AdditionalReactionTrixtaDataType;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   data: any;
 };

--- a/src/React/reduxActions/internal/types.ts
+++ b/src/React/reduxActions/internal/types.ts
@@ -1,5 +1,19 @@
 import { JOIN_TRIXTA_ROLE, UPDATE_TRIXTA_ERROR } from '../../constants';
 
+export interface TrixtaReactionMetaDataType extends AdditionalTrixtaData {
+  ref?: string;
+  reactionName: string;
+}
+
+export interface TrixtaActionMetaDataType extends AdditionalTrixtaData {
+  actionName: string;
+}
+
+export type AdditionalTrixtaDataType = {
+  extraData?: Record<string, unknown>;
+  trixtaMeta: TrixtaReactionMetaDataType | TrixtaActionMetaDataType;
+};
+
 export type AdditionalTrixtaData = {
   roleName: string;
   clearResponse?: boolean;


### PR DESCRIPTION
### What:

fix types on onSuccess or onError callbacks for hooks

### How:

remove the default passed types

### Comments:

<!-- feel free to add additional comments -->
