### PR TITLE
feat: trixta auth refactored

### DIFF
--- a/src/React/components/TrixtaAuthComponent/TrixtaAuth.stories.tsx
+++ b/src/React/components/TrixtaAuthComponent/TrixtaAuth.stories.tsx
@@ -26,7 +26,7 @@ const Template: ComponentStory<typeof TrixtaAuthComponent> = (
   args,
   globals,
 ) => (
-  <TrixtaAuthComponent {...args} roles={getGlobalsRoleName(globals)}>
+  <TrixtaAuthComponent {...args} roleName={getGlobalsRoleName(globals)}>
     {<div>You can only see me if you have access</div>}
   </TrixtaAuthComponent>
 );

--- a/src/React/components/TrixtaAuthComponent/TrixtaAuthComponent.tsx
+++ b/src/React/components/TrixtaAuthComponent/TrixtaAuthComponent.tsx
@@ -1,21 +1,17 @@
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { makeSelectHasTrixtaRoleAccessForRoles } from '../../selectors';
+import { makeSelectHasTrixtaRoleAccessForRole } from '../../selectors';
 import { TrixtaState } from '../../types';
 import { TrixtaAuthProps } from './types';
 
 const TrixtaAuthComponent = ({
   children,
-  roles,
+  roleName,
   ...rest
 }: TrixtaAuthProps & { children: React.ReactNode }): JSX.Element | null => {
-  const roleAccessSelector = useMemo(makeSelectHasTrixtaRoleAccessForRoles, []);
-  const rolesArr = useMemo(
-    () => (Array.isArray(roles) ? roles : roles ? [roles] : []),
-    [roles],
-  );
+  const roleAccessSelector = useMemo(makeSelectHasTrixtaRoleAccessForRole, []);
   const hasRoleAccess = useSelector((state: { trixta: TrixtaState }) =>
-    roleAccessSelector(state, { roles: rolesArr }),
+    roleAccessSelector(state, { roleName }),
   );
 
   if (!hasRoleAccess) return null;

--- a/src/React/components/TrixtaAuthComponent/types.ts
+++ b/src/React/components/TrixtaAuthComponent/types.ts
@@ -1,8 +1,8 @@
 export interface TrixtaAuthProps {
   /**
-   * Trixta roles or role name
+   * Trixta role name
    */
-  roles?: string | string[];
+  roleName: string;
   /**
    * Children can be a render props function or a react component
    */

--- a/src/React/hooks/use-respond-to-reaction-effect/index.test.tsx
+++ b/src/React/hooks/use-respond-to-reaction-effect/index.test.tsx
@@ -46,7 +46,7 @@ describe('useRespondToReactionEffect', () => {
 
   it('should return hasRoleAccess true, for roleName: everyone_authed', () => {
     const { wrapper } = mockStoreProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const { result } = renderHook(
       () =>
         useRespondToReactionEffect({
@@ -63,7 +63,7 @@ describe('useRespondToReactionEffect', () => {
 
   it('Redux store should contain actionToDispatch, for roleName: viewer[d1be63be-c0e4-4468-982c-5c04714a2987] and reactionName: new_waitroom_status', () => {
     const { wrapper, store } = mockStoreProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[1];
+    const roleName = 'viewer[d1be63be-c0e4-4468-982c-5c04714a2987]';
     const reactionName = 'new_waitroom_status';
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const actionToDispatch = (payload: any) => ({
@@ -92,7 +92,7 @@ describe('useRespondToReactionEffect', () => {
 
   it('Redux store should contain dispatchResponseTo, for roleName: viewer[d1be63be-c0e4-4468-982c-5c04714a2987] and reactionName: new_waitroom_status', () => {
     const { wrapper, store } = mockStoreProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[1];
+    const roleName = 'viewer[d1be63be-c0e4-4468-982c-5c04714a2987]';
     const reactionName = 'new_waitroom_status';
     const dispatchResponseTo = 'TEST_ACTION';
     const initialReactionData =
@@ -120,7 +120,7 @@ describe('useRespondToReactionEffect', () => {
 
   it('callback for roleName: viewer[d1be63be-c0e4-4468-982c-5c04714a2987] and reactionName: new_waitroom_status should be called with data', () => {
     const { wrapper } = mockStoreProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[1];
+    const roleName = 'viewer[d1be63be-c0e4-4468-982c-5c04714a2987]';
     const reactionName = 'new_waitroom_status';
 
     const initialReactionData =

--- a/src/React/hooks/use-respond-to-reaction-response/index.test.tsx
+++ b/src/React/hooks/use-respond-to-reaction-response/index.test.tsx
@@ -53,7 +53,7 @@ describe('useRespondToReactionResponse', () => {
 
   it('should return hasRoleAccess true, for roleName: everyone_authed', () => {
     const { wrapper } = mockStoreProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const { result } = renderHook(
       () =>
         useRespondToReactionResponse({
@@ -70,7 +70,7 @@ describe('useRespondToReactionResponse', () => {
 
   it('Redux store should contain SubmitTrixtaReactionResponseAction, for roleName: host[d1be63be-c0e4-4468-982c-5c04714a2987] and reactionName: request_guest_stream', () => {
     const { wrapper, store } = mockStoreProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[2];
+    const roleName = 'host[d1be63be-c0e4-4468-982c-5c04714a2987]';
     const reactionName = 'request_guest_stream';
     const ref =
       trixtaState.reactions[

--- a/src/React/hooks/use-trixta-access/index.test.tsx
+++ b/src/React/hooks/use-trixta-access/index.test.tsx
@@ -7,7 +7,7 @@ import { useTrixtaAccess } from './use-trixta-access';
 describe('useTrixtaAccess', () => {
   it('should return the correct default values', () => {
     const { wrapper } = storeProviderWrapper();
-    const { result } = renderHook(() => useTrixtaAccess({}), {
+    const { result } = renderHook(() => useTrixtaAccess({ roleName: '' }), {
       wrapper,
     });
 
@@ -19,13 +19,13 @@ describe('useTrixtaAccess', () => {
     const { wrapper } = storeProviderWrapper(
       mockDefaultTrixtaState({
         authorizationStarted: true,
-        agentDetails: [role],
+        agentDetails: { 'guest[d1be63be-c0e4-4468-982c-5c04714a2987]': true },
       }),
     );
     const { result } = renderHook(
       () =>
         useTrixtaAccess({
-          roles: [role],
+          roleName: role,
         }),
       {
         wrapper,
@@ -39,13 +39,13 @@ describe('useTrixtaAccess', () => {
     const { wrapper } = storeProviderWrapper(
       mockDefaultTrixtaState({
         authorizationStarted: true,
-        agentDetails: [role],
+        agentDetails: { 'guest[d1be63be-c0e4-4468-982c-5c04714a2987]': true },
       }),
     );
     const { result } = renderHook(
       () =>
         useTrixtaAccess({
-          roles: role,
+          roleName: role,
         }),
       {
         wrapper,
@@ -60,13 +60,13 @@ describe('useTrixtaAccess', () => {
     const { wrapper } = storeProviderWrapper(
       mockDefaultTrixtaState({
         authorizationStarted: true,
-        agentDetails: ['guest[d1be63be-c0e4-4468-982c-5c04714a2987]'],
+        agentDetails: { 'guest[d1be63be-c0e4-4468-982c-5c04714a2987]': true },
       }),
       {
         details: { token: 'dummyToken' },
       },
     );
-    const { result } = renderHook(() => useTrixtaAccess({ roles: role }), {
+    const { result } = renderHook(() => useTrixtaAccess({ roleName: role }), {
       wrapper,
     });
 

--- a/src/React/hooks/use-trixta-access/types.ts
+++ b/src/React/hooks/use-trixta-access/types.ts
@@ -1,6 +1,6 @@
 export interface UseTrixtaAccessProps {
   /**
-   * Trixta roles or role name
+   * Trixta role name
    */
-  roles?: string | string[];
+  roleName: string;
 }

--- a/src/React/hooks/use-trixta-access/use-trixta-access.ts
+++ b/src/React/hooks/use-trixta-access/use-trixta-access.ts
@@ -1,20 +1,16 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { makeSelectHasTrixtaRoleAccessForRoles } from '../../selectors';
+import { makeSelectHasTrixtaRoleAccessForRole } from '../../selectors';
 import { TrixtaState } from '../../types/common';
 import { UseTrixtaAccessProps } from './types';
 
 export const useTrixtaAccess = ({
-  roles = [],
-}: UseTrixtaAccessProps | undefined = {}): boolean => {
-  const rolesArr = useMemo(
-    () => (Array.isArray(roles) ? roles : roles ? [roles] : []),
-    [roles],
+  roleName,
+}: UseTrixtaAccessProps): boolean => {
+  const roleAccessSelector = useMemo(makeSelectHasTrixtaRoleAccessForRole, []);
+  const hasRole = useSelector<{ trixta: TrixtaState }, boolean>((state) =>
+    roleAccessSelector(state, { roleName }),
   );
-  const roleAccessSelector = useMemo(makeSelectHasTrixtaRoleAccessForRoles, []);
-  const hasRoles = useSelector<{ trixta: TrixtaState }, boolean>((state) =>
-    roleAccessSelector(state, { roles: rolesArr }),
-  );
-  const hasAccess = useMemo(() => hasRoles, [hasRoles]);
+  const hasAccess = useMemo(() => hasRole, [hasRole]);
   return hasAccess;
 };

--- a/src/React/hooks/use-trixta-access/useTrixtaAccess.stories.tsx
+++ b/src/React/hooks/use-trixta-access/useTrixtaAccess.stories.tsx
@@ -35,5 +35,5 @@ const ComponentTemplate: Story<UseTrixtaAccessProps> = (args, globals) => {
 };
 export const Default = ComponentTemplate.bind({});
 Default.args = {
-  roles: DEFAULT_TRIXTA_ROLE,
+  roleName: DEFAULT_TRIXTA_ROLE,
 };

--- a/src/React/hooks/use-trixta-action-reaction/index.test.tsx
+++ b/src/React/hooks/use-trixta-action-reaction/index.test.tsx
@@ -7,7 +7,7 @@ import { useTrixtaActionReaction } from './use-trixta-action-reaction';
 describe('useTrixtaActionReaction', () => {
   it('should throw error if no actionName parameter', () => {
     const { wrapper } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const { result } = renderHook(
       () =>
         useTrixtaActionReaction({
@@ -26,7 +26,7 @@ describe('useTrixtaActionReaction', () => {
 
   it('should throw error if no reactionName parameter', () => {
     const { wrapper } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const { result } = renderHook(
       () =>
         useTrixtaActionReaction({
@@ -78,7 +78,7 @@ describe('useTrixtaActionReaction', () => {
 
   it('should return hasRoleAccess true, for roleName: everyone_authed', () => {
     const { wrapper } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const { result } = renderHook(
       () =>
         useTrixtaActionReaction({
@@ -98,7 +98,7 @@ describe('useTrixtaActionReaction', () => {
 
   it('should return hasRoleAccess true,even if not specifying reactionProps roleName for roleName: everyone_authed', () => {
     const { wrapper } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const { result } = renderHook(
       () =>
         useTrixtaActionReaction({
@@ -118,7 +118,7 @@ describe('useTrixtaActionReaction', () => {
 
   it('should return callbacks clearActionResponses,clearReactionResponses,submitTrixtaReactionResponse,submitTrixtaActionResponse', () => {
     const { wrapper } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const { result } = renderHook(
       () =>
         useTrixtaActionReaction({
@@ -141,7 +141,7 @@ describe('useTrixtaActionReaction', () => {
 
   it('should return actionResponse undefined for non existent actionName: test and roleName: everyone_authed', () => {
     const { wrapper } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const { result } = renderHook(
       () =>
         useTrixtaActionReaction({
@@ -161,7 +161,7 @@ describe('useTrixtaActionReaction', () => {
 
   it('should return actionResponse existent actionName: request_user_info_request and roleName: everyone_authed', () => {
     const { wrapper } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const actionName = 'request_user_info';
     const { result } = renderHook(
       () =>
@@ -182,7 +182,7 @@ describe('useTrixtaActionReaction', () => {
 
   it('should return hasResponse, hasActionResponse true for existent actionName: request_user_info_request and roleName: everyone_authed', () => {
     const { wrapper } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const actionName = 'request_user_info';
     const { result } = renderHook(
       () =>
@@ -204,7 +204,7 @@ describe('useTrixtaActionReaction', () => {
 
   it('should clear responses, when calling clearActionResponses for actionName: request_user_info and roleName: everyone_authed', () => {
     const { wrapper } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const actionName = 'request_user_info';
     const { result } = renderHook(
       () =>
@@ -233,7 +233,7 @@ describe('useTrixtaActionReaction', () => {
 
   it('should return isInProgress true, when submitTrixtaActionResponse for actionName: request_user_info_request and roleName: everyone_authed', () => {
     const { wrapper } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const actionName = 'request_user_info_request';
     const { result } = renderHook(
       () =>
@@ -262,7 +262,7 @@ describe('useTrixtaActionReaction', () => {
 
   it('should return isInProgress true, when submitTrixtaActionResponse for actionName: request_user_info_request and roleName: everyone_authed and loadingStatusRef: info', () => {
     const { wrapper } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const actionName = 'request_user_info_request';
     const { result } = renderHook(
       () =>
@@ -294,7 +294,7 @@ describe('useTrixtaActionReaction', () => {
 
   it('should autosubmit trixta action on mount, when autosubmit true for actionName: request_user_info_request and roleName: everyone_authed', () => {
     const { wrapper } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const actionName = 'request_user_info_request';
     const { result } = renderHook(
       () =>
@@ -318,7 +318,7 @@ describe('useTrixtaActionReaction', () => {
 
   it('should autosubmit trixta action on mount with actionParameters, when autosubmit true for actionName: request_user_info_request and roleName: everyone_authed', () => {
     const { wrapper } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const actionName = 'request_user_info_request';
     const { result } = renderHook(
       () =>

--- a/src/React/hooks/use-trixta-action/index.test.tsx
+++ b/src/React/hooks/use-trixta-action/index.test.tsx
@@ -48,7 +48,7 @@ describe('useTrixtaAction', () => {
 
   it('should return hasRoleAccess true, for roleName: everyone_authed', () => {
     const { wrapper } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const { result } = renderHook(
       () =>
         useTrixtaAction({
@@ -65,7 +65,7 @@ describe('useTrixtaAction', () => {
 
   it('should return callbacks clearActionResponses and submitTrixtaAction', () => {
     const { wrapper } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const { result } = renderHook(
       () =>
         useTrixtaAction({
@@ -83,7 +83,7 @@ describe('useTrixtaAction', () => {
 
   it('should return response,latestInstance undefined for non existent actionName: test and roleName: everyone_authed', () => {
     const { wrapper } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const { result } = renderHook(
       () =>
         useTrixtaAction({
@@ -102,7 +102,7 @@ describe('useTrixtaAction', () => {
 
   it('should return response, latestInstance existent actionName: request_user_info_request and roleName: everyone_authed', () => {
     const { wrapper } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const actionName = 'request_user_info';
     const { result } = renderHook(
       () =>
@@ -121,7 +121,7 @@ describe('useTrixtaAction', () => {
 
   it('should return hasResponse true for existent actionName: request_user_info_request and roleName: everyone_authed', () => {
     const { wrapper } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const actionName = 'request_user_info';
     const { result } = renderHook(
       () =>
@@ -139,7 +139,7 @@ describe('useTrixtaAction', () => {
 
   it('should clear responses, when calling clearActionResponses for actionName: request_user_info and roleName: everyone_authed', () => {
     const { wrapper } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const actionName = 'request_user_info';
     const { result } = renderHook(
       () =>
@@ -166,7 +166,7 @@ describe('useTrixtaAction', () => {
 
   it('should clear responses, with option clearResponsesOnCallback prop for actionName: request_user_info and roleName: everyone_authed', () => {
     const { wrapper, store } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const actionName = 'request_user_info';
     const trixtaMeta = { roleName, actionName };
     const onSuccess = jest.fn();
@@ -207,7 +207,7 @@ describe('useTrixtaAction', () => {
 
   it('should return isInProgress true, when submitTrixtaAction for actionName: request_user_info_request and roleName: everyone_authed', () => {
     const { wrapper } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const actionName = 'request_user_info_request';
     const { result } = renderHook(
       () =>
@@ -234,7 +234,7 @@ describe('useTrixtaAction', () => {
 
   it('should return isInProgress true, when submitTrixtaAction for actionName: request_user_info_request and roleName: everyone_authed and loadingStatusRef: info', () => {
     const { wrapper } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const actionName = 'request_user_info_request';
     const { result } = renderHook(
       () =>
@@ -262,7 +262,7 @@ describe('useTrixtaAction', () => {
 
   it('should pass success response, when calling onSuccess for actionName: request_user_info_request and roleName: everyone_authed', () => {
     const { wrapper, store } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const successResponse = {
       email: 'jacques+guest@trixta.com',
       firstName: 'Jacques',
@@ -322,7 +322,7 @@ describe('useTrixtaAction', () => {
 
   it('should call onSuccess once for actionName: request_user_info_request and roleName: everyone_authed', () => {
     const { wrapper, store } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const successResponse = {
       email: 'jacques+guest@trixta.com',
       firstName: 'Jacques',
@@ -400,7 +400,7 @@ describe('useTrixtaAction', () => {
 
   it('should pass error response, when calling onError for actionName: request_user_info_request and roleName: everyone_authed', () => {
     const { wrapper, store } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const errorResponse = {
       message: 'this is an error',
     };
@@ -454,7 +454,7 @@ describe('useTrixtaAction', () => {
   });
   it('should autosubmit trixta action on mount, when autosubmit true for actionName: request_user_info_request and roleName: everyone_authed', () => {
     const { wrapper } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const actionName = 'request_user_info_request';
     const { result } = renderHook(
       () =>
@@ -476,7 +476,7 @@ describe('useTrixtaAction', () => {
 
   it('should autosubmit trixta action on mount with actionParameters, when autosubmit true for actionName: request_user_info_request and roleName: everyone_authed and when role access changes', () => {
     const { store, wrapper } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     act(() => {
       store.dispatch(leaveTrixtaRole({ roleName }));
     });
@@ -513,7 +513,7 @@ describe('useTrixtaAction', () => {
 
   it('should autosubmit trixta action on mount with actionParameters, when autosubmit true for actionName: request_user_info_request and roleName: everyone_authed', () => {
     const { wrapper } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const actionName = 'request_user_info_request';
     const { result } = renderHook(
       () =>
@@ -536,7 +536,7 @@ describe('useTrixtaAction', () => {
 
   it('success type should match props type', () => {
     const { wrapper, store } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const actionName = 'request_user_info_request';
     const trixtaMeta = { actionName, roleName };
     type successResponseType = {
@@ -588,7 +588,7 @@ describe('useTrixtaAction', () => {
 
   it('error type should match props type', () => {
     const { wrapper, store } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const actionName = 'request_user_info_request';
     const trixtaMeta = { actionName, roleName };
     type errorResponseType = {

--- a/src/React/hooks/use-trixta-auth/types.ts
+++ b/src/React/hooks/use-trixta-auth/types.ts
@@ -1,8 +1,8 @@
 export interface UseTrixtaAuthProps {
   /**
-   * Trixta roles or role name
+   * Trixta role name
    */
-  roles?: string | string[];
+  roleName?: string;
 }
 
 export interface UseTrixtaAuthHookReturn {
@@ -11,9 +11,9 @@ export interface UseTrixtaAuthHookReturn {
    */
   isAuthenticated?: boolean;
   /**
-   * If 'true', Trixta roles or role name passed does have acccess for this user
+   * If 'true', Trixta role name passed does have acccess for this user
    */
-  hasRoles: boolean;
+  hasRole: boolean;
   /**
    * If 'true', Trixta roles or role name passed does have acccess for this user and isAuthenticated
    */

--- a/src/React/hooks/use-trixta-auth/useTrixtaAuth.stories.tsx
+++ b/src/React/hooks/use-trixta-auth/useTrixtaAuth.stories.tsx
@@ -32,5 +32,5 @@ const ComponentTemplate: Story<UseTrixtaAuthProps> = (args, globals) => {
 };
 export const Default = ComponentTemplate.bind({});
 Default.args = {
-  roles: DEFAULT_TRIXTA_ROLE,
+  roleName: DEFAULT_TRIXTA_ROLE,
 };

--- a/src/React/hooks/use-trixta-data/use-trixta-data.ts
+++ b/src/React/hooks/use-trixta-data/use-trixta-data.ts
@@ -20,9 +20,10 @@ export const useTrixtaData = ({
   >();
 
   const selectTrixtaRoles = useMemo(makeSelectTrixtaAgentDetails, []);
-  const roles = useSelector<{ trixta: TrixtaState }, string[]>((state) =>
-    selectTrixtaRoles(state),
+  const roleMap = useSelector<{ trixta: TrixtaState }, Record<string, boolean>>(
+    (state) => selectTrixtaRoles(state),
   );
+  const roles = Object.keys(roleMap);
   const selectTrixtaActions = useMemo(makeSelectTrixtaActionsForRole, []);
   const actions = useSelector<
     { trixta: TrixtaState },

--- a/src/React/hooks/use-trixta-reaction/index.test.tsx
+++ b/src/React/hooks/use-trixta-reaction/index.test.tsx
@@ -58,7 +58,7 @@ describe('useTrixtaReaction', () => {
 
   it('should return hasRoleAccess true, for roleName: everyone_authed', () => {
     const { wrapper } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[0];
+    const roleName = 'everyone_authed';
     const { result } = renderHook(
       () =>
         useTrixtaReaction({
@@ -75,7 +75,7 @@ describe('useTrixtaReaction', () => {
 
   it('should return callbacks clearReactionResponses  and submitTrixtaReaction', () => {
     const { wrapper } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[1];
+    const roleName = 'viewer[d1be63be-c0e4-4468-982c-5c04714a2987]';
     const { result } = renderHook(
       () =>
         useTrixtaReaction({
@@ -93,7 +93,7 @@ describe('useTrixtaReaction', () => {
 
   it('should return latestResponse,latestInstance undefined for non existent reactionName: test', () => {
     const { wrapper } = storeProviderWrapper(trixtaState);
-    const roleName = trixtaState.agentDetails[1];
+    const roleName = 'viewer[d1be63be-c0e4-4468-982c-5c04714a2987]';
     const { result } = renderHook(
       () =>
         useTrixtaReaction({
@@ -113,7 +113,7 @@ describe('useTrixtaReaction', () => {
   describe('useTrixtaReaction with requestForEffect true', () => {
     it('should return response, latestInstance existent reactionName: set_queue', () => {
       const { wrapper } = storeProviderWrapper(trixtaState);
-      const roleName = trixtaState.agentDetails[1];
+      const roleName = 'viewer[d1be63be-c0e4-4468-982c-5c04714a2987]';
       const reactionName = 'set_queue';
       const { result } = renderHook(
         () =>
@@ -133,7 +133,7 @@ describe('useTrixtaReaction', () => {
 
     it('should return hasResponse true for existent for reactionName: set_queue and roleName: viewer[d1be63be-c0e4-4468-982c-5c04714a2987]', () => {
       const { wrapper } = storeProviderWrapper(trixtaState);
-      const roleName = trixtaState.agentDetails[1];
+      const roleName = 'viewer[d1be63be-c0e4-4468-982c-5c04714a2987]';
       const reactionName = 'set_queue';
       const { result } = renderHook(
         () =>
@@ -152,7 +152,7 @@ describe('useTrixtaReaction', () => {
 
     it('should clear responses, when calling clearReactionResponses for reactionName: set_queue and roleName: viewer[d1be63be-c0e4-4468-982c-5c04714a2987]', () => {
       const { wrapper } = storeProviderWrapper(trixtaState);
-      const roleName = trixtaState.agentDetails[1];
+      const roleName = 'viewer[d1be63be-c0e4-4468-982c-5c04714a2987]';
       const reactionName = 'set_queue';
       const { result } = renderHook(
         () =>
@@ -179,7 +179,7 @@ describe('useTrixtaReaction', () => {
     });
     it('should return loading true, for reactionName: test_reaction and roleName: viewer[d1be63be-c0e4-4468-982c-5c04714a2987]', () => {
       const { wrapper, store } = storeProviderWrapper(trixtaState);
-      const roleName = trixtaState.agentDetails[1];
+      const roleName = 'viewer[d1be63be-c0e4-4468-982c-5c04714a2987]';
       const reactionName = trixtaReactionCommon.name as string;
       const { result } = renderHook(
         () =>
@@ -213,7 +213,7 @@ describe('useTrixtaReaction', () => {
 
     it('should return loading false, for reactionName: test_reaction and roleName: viewer[d1be63be-c0e4-4468-982c-5c04714a2987]', () => {
       const { wrapper, store } = storeProviderWrapper(trixtaState);
-      const roleName = trixtaState.agentDetails[1];
+      const roleName = 'viewer[d1be63be-c0e4-4468-982c-5c04714a2987]';
       const reactionName = trixtaReactionCommon.name as string;
       const { result } = renderHook(
         () =>
@@ -264,7 +264,7 @@ describe('useTrixtaReaction', () => {
 
     it('should return initial_data, for reactionName: test_reaction and roleName: viewer[d1be63be-c0e4-4468-982c-5c04714a2987]', () => {
       const { wrapper, store } = storeProviderWrapper(trixtaState);
-      const roleName = trixtaState.agentDetails[1];
+      const roleName = 'viewer[d1be63be-c0e4-4468-982c-5c04714a2987]';
       const reactionName = trixtaReactionCommon.name as string;
       const { result } = renderHook(
         () =>
@@ -316,7 +316,7 @@ describe('useTrixtaReaction', () => {
   describe('useTrixtaReaction with requestForEffect false', () => {
     it('should return response, latestInstance existent for reactionName: request_guest_stream and roleName: host[d1be63be-c0e4-4468-982c-5c04714a2987]', () => {
       const { wrapper } = storeProviderWrapper(trixtaState);
-      const roleName = trixtaState.agentDetails[2];
+      const roleName = 'host[d1be63be-c0e4-4468-982c-5c04714a2987]';
       const reactionName = 'request_guest_stream';
       const { result } = renderHook(
         () =>
@@ -335,7 +335,7 @@ describe('useTrixtaReaction', () => {
 
     it('should return hasResponse true for existent for reactionName: request_guest_stream and roleName: host[d1be63be-c0e4-4468-982c-5c04714a2987]', () => {
       const { wrapper } = storeProviderWrapper(trixtaState);
-      const roleName = trixtaState.agentDetails[2];
+      const roleName = 'host[d1be63be-c0e4-4468-982c-5c04714a2987]';
       const reactionName = 'request_guest_stream';
       const { result } = renderHook(
         () =>
@@ -353,7 +353,7 @@ describe('useTrixtaReaction', () => {
 
     it('should clear responses, when calling clearReactionResponses for reactionName: request_guest_stream and roleName: host[d1be63be-c0e4-4468-982c-5c04714a2987]', () => {
       const { wrapper } = storeProviderWrapper(trixtaState);
-      const roleName = trixtaState.agentDetails[2];
+      const roleName = 'host[d1be63be-c0e4-4468-982c-5c04714a2987]';
       const reactionName = 'request_guest_stream';
       const { result } = renderHook(
         () =>
@@ -380,7 +380,7 @@ describe('useTrixtaReaction', () => {
 
     it('should clear responses, with clearResponsesOnCallback prop for reactionName: request_guest_stream and roleName: host[d1be63be-c0e4-4468-982c-5c04714a2987]', () => {
       const { wrapper, store } = storeProviderWrapper(trixtaState);
-      const roleName = trixtaState.agentDetails[2];
+      const roleName = 'host[d1be63be-c0e4-4468-982c-5c04714a2987]';
       const reactionName = 'request_guest_stream';
       const onSuccess = jest.fn();
       const { result } = renderHook(
@@ -426,7 +426,7 @@ describe('useTrixtaReaction', () => {
 
     it('should return isInProgress true, when submitTrixtaReaction for reactionName: request_guest_stream and roleName: host[d1be63be-c0e4-4468-982c-5c04714a2987]', () => {
       const { wrapper } = storeProviderWrapper(trixtaState);
-      const roleName = trixtaState.agentDetails[2];
+      const roleName = 'host[d1be63be-c0e4-4468-982c-5c04714a2987]';
       const reactionName = 'request_guest_stream';
       const { result } = renderHook(
         () =>
@@ -456,7 +456,7 @@ describe('useTrixtaReaction', () => {
 
     it('should return isInProgress true, when submitTrixtaReaction for reactionName: request_guest_stream and roleName: host[d1be63be-c0e4-4468-982c-5c04714a2987] and loadingStatusRef: streams', () => {
       const { wrapper } = storeProviderWrapper(trixtaState);
-      const roleName = trixtaState.agentDetails[2];
+      const roleName = 'host[d1be63be-c0e4-4468-982c-5c04714a2987]';
       const reactionName = 'request_guest_stream';
       const { result } = renderHook(
         () =>
@@ -487,7 +487,7 @@ describe('useTrixtaReaction', () => {
 
     it('should pass success response, when calling onSuccess for actionName: request_guest_stream and roleName: host[d1be63be-c0e4-4468-982c-5c04714a2987]', () => {
       const { wrapper, store } = storeProviderWrapper(trixtaState);
-      const roleName = trixtaState.agentDetails[2];
+      const roleName = 'host[d1be63be-c0e4-4468-982c-5c04714a2987]';
       const reactionName = 'request_guest_stream';
       const ref =
         trixtaState.reactions[
@@ -543,7 +543,7 @@ describe('useTrixtaReaction', () => {
 
     it('should pass error response, when calling onError for reactionName: request_guest_stream and roleName: host[d1be63be-c0e4-4468-982c-5c04714a2987]', () => {
       const { wrapper, store } = storeProviderWrapper(trixtaState);
-      const roleName = trixtaState.agentDetails[2];
+      const roleName = 'host[d1be63be-c0e4-4468-982c-5c04714a2987]';
       const errorResponse = {
         message: 'this is an error',
       };

--- a/src/React/hooks/use-trixta-role-unmount/index.test.tsx
+++ b/src/React/hooks/use-trixta-role-unmount/index.test.tsx
@@ -17,7 +17,7 @@ describe('useTrixtaRoleUnmount', () => {
       },
     );
 
-    expect(store.getState().trixta.agentDetails).toContain(
+    expect(store.getState().trixta.agentDetails).toHaveProperty(
       'guest[d1be63be-c0e4-4468-982c-5c04714a2987]',
     );
   });
@@ -38,7 +38,7 @@ describe('useTrixtaRoleUnmount', () => {
       unmount();
     });
 
-    expect(store.getState().trixta.agentDetails).not.toContain(
+    expect(store.getState().trixta.agentDetails).not.toHaveProperty(
       'guest[d1be63be-c0e4-4468-982c-5c04714a2987]',
     );
   });

--- a/src/React/reducers/__mocks__/trixtaState.ts
+++ b/src/React/reducers/__mocks__/trixtaState.ts
@@ -653,12 +653,12 @@ export const mockTrixtaActions: TrixtaState['actions'] = {
   },
 };
 
-export const mockTrixtaAgentDetails = [
-  'everyone_authed',
-  'viewer[d1be63be-c0e4-4468-982c-5c04714a2987]',
-  'host[d1be63be-c0e4-4468-982c-5c04714a2987]',
-  'guest[d1be63be-c0e4-4468-982c-5c04714a2987]',
-];
+export const mockTrixtaAgentDetails = {
+  everyone_authed: true,
+  'viewer[d1be63be-c0e4-4468-982c-5c04714a2987]': true,
+  'host[d1be63be-c0e4-4468-982c-5c04714a2987]': true,
+  'guest[d1be63be-c0e4-4468-982c-5c04714a2987]': true,
+};
 
 export const mockAuthorizingStatus = {
   'guest[d1be63be-c0e4-4468-982c-5c04714a2987]': {
@@ -678,7 +678,7 @@ export const trixtaState: TrixtaState = {
 export const mockDefaultTrixtaState = ({
   authorizationStarted = false,
   authorizingStatus = {},
-  agentDetails = [],
+  agentDetails = {},
 }: {
   authorizationStarted?: TrixtaState['authorizationStarted'];
   authorizingStatus?: TrixtaState['authorizingStatus'];

--- a/src/React/reducers/__tests__/reducers.test.ts
+++ b/src/React/reducers/__tests__/reducers.test.ts
@@ -75,17 +75,14 @@ describe('trixtaReducer', () => {
     const expectedResult = produce<TrixtaState>(state, (draft) => {
       draft.authorizationStarted = true;
       const roleName = action.payload.roleName;
-      const index = draft.agentDetails.findIndex((role) => role === roleName);
-      if (index === -1) {
-        draft.agentDetails.push(roleName);
-      }
+      if (!state.agentDetails[roleName]) draft.agentDetails[roleName] = true;
       delete draft.authorizingStatus[roleName];
     });
     expect(
       trixtaReducer(state, actions.joinTrixtaRole(action.payload)),
     ).toEqual(expectedResult);
     expect(expectedResult.authorizingStatus[nameOfRole]).toEqual(undefined);
-    expect(expectedResult.agentDetails).toContain(nameOfRole);
+    expect(expectedResult.agentDetails).toHaveProperty(nameOfRole);
   });
 
   it('should handle the updateTrixtaRole action correctly', () => {
@@ -95,8 +92,7 @@ describe('trixtaReducer', () => {
     const expectedResult = produce<TrixtaState>(state, (draft) => {
       const roleName = action.payload.role.name;
       if (roleName) {
-        const index = draft.agentDetails.findIndex((role) => role === roleName);
-        if (index === -1) {
+        if (!draft.agentDetails[roleName]) {
           draft.authorizingStatus[roleName] = { status: true };
         }
       }
@@ -122,8 +118,7 @@ describe('trixtaReducer', () => {
     state = trixtaState;
     const expectedResult = produce<TrixtaState>(state, (draft) => {
       action.payload.roles.forEach(({ name }: TrixtaRoleParameter) => {
-        const index = draft.agentDetails.findIndex((role) => role === name);
-        if (index === -1) {
+        if (!draft.agentDetails[name]) {
           draft.authorizingStatus[name] = { status: true };
         }
       });
@@ -151,12 +146,11 @@ describe('trixtaReducer', () => {
     state = trixtaState;
     const expectedResult = produce<TrixtaState>(state, (draft) => {
       const roleName = action.payload.role.name;
-      const index = draft.agentDetails.findIndex((role) => role === roleName);
       delete draft.authorizingStatus[roleName];
-      if (index !== -1) draft.agentDetails.splice(index, 1);
+      delete draft.agentDetails[roleName];
       draft.reactions = pickBy(
         state.reactions,
-        (value, key) => key && key.split(':', 1)[0] !== roleName,
+        (_, key) => key && key.split(':', 1)[0] !== roleName,
       );
       draft.actions = pickBy(
         state.actions,

--- a/src/React/reducers/trixtaReducer.ts
+++ b/src/React/reducers/trixtaReducer.ts
@@ -46,7 +46,7 @@ import { TrixtaState } from './../types';
 export const initialState: TrixtaState = {
   authorizationStarted: false,
   authorizingStatus: {},
-  agentDetails: [],
+  agentDetails: {},
   reactions: {},
   actions: {},
   error: false,
@@ -80,11 +80,8 @@ export const trixtaReducer = (
       case REMOVE_TRIXTA_ROLE:
         {
           const roleName = action.payload.role.name;
-          const index = draft.agentDetails.findIndex(
-            (role) => role === roleName,
-          );
           delete draft.authorizingStatus[roleName];
-          if (index !== -1) draft.agentDetails.splice(index, 1);
+          delete draft.agentDetails[roleName];
           draft.reactions = pickBy(
             state.reactions,
             (_, key) => key && key.split(':', 1)[0] !== roleName,
@@ -97,18 +94,14 @@ export const trixtaReducer = (
         break;
       case LEAVE_TRIXTA_ROLE: {
         const roleName = action.payload.roleName;
-        const index = draft.agentDetails.findIndex((role) => role === roleName);
         delete draft.authorizingStatus[roleName];
-        if (index !== -1) draft.agentDetails.splice(index, 1);
+        delete draft.agentDetails[roleName];
         break;
       }
       case JOIN_TRIXTA_ROLE: {
         draft.authorizationStarted = true;
         const roleName = action.payload.roleName;
-        const index = draft.agentDetails.findIndex((role) => role === roleName);
-        if (index === -1) {
-          draft.agentDetails.push(roleName);
-        }
+        if (!state.agentDetails[roleName]) draft.agentDetails[roleName] = true;
         delete draft.authorizingStatus[roleName];
         break;
       }
@@ -116,10 +109,7 @@ export const trixtaReducer = (
         {
           const roleName = action.payload.role.name;
           if (roleName) {
-            const index = draft.agentDetails.findIndex(
-              (role) => role === roleName,
-            );
-            if (index === -1) {
+            if (!draft.agentDetails[roleName]) {
               draft.authorizingStatus[roleName] = { status: true };
             }
           }
@@ -127,8 +117,7 @@ export const trixtaReducer = (
         break;
       case UPDATE_TRIXTA_ROLES:
         action.payload.roles.forEach(({ name }: TrixtaRoleParameter) => {
-          const index = draft.agentDetails.findIndex((role) => role === name);
-          if (index === -1) {
+          if (!draft.agentDetails[name]) {
             draft.authorizingStatus[name] = { status: true };
           }
         });

--- a/src/React/sagas/setupTrixtaSaga.ts
+++ b/src/React/sagas/setupTrixtaSaga.ts
@@ -634,7 +634,7 @@ function* handleChannelLeaveSaga({ channel }: { channel: Channel }) {
   const agentDetails: TrixtaState['agentDetails'] = yield select(
     makeSelectTrixtaAgentDetails(),
   );
-  if (agentDetails && agentDetails.includes(roleName)) {
+  if (agentDetails && agentDetails[roleName]) {
     yield put(removeTrixtaRole({ name: roleName }));
   }
 }

--- a/src/React/selectors/tests/common/selectors.test.js
+++ b/src/React/selectors/tests/common/selectors.test.js
@@ -1,4 +1,4 @@
-import { get, isNullOrEmpty } from '../../../../utils';
+import { get } from '../../../../utils';
 // eslint-disable-next-line jest/no-mocks-import
 import {
   mockedState,
@@ -145,39 +145,30 @@ describe('Trixta Selectors', () => {
     it('makeSelectHasTrixtaRoleAccess', () => {
       const selector = trixtaCommonSelectors.makeSelectHasTrixtaRoleAccess();
       const props = { roleName: 'guest[d1be63be-c0e4-4468-982c-5c04714a2987]' };
-      const agentDetails = trixtaCommonSelectors.selectTrixtaAgentDetails(
-        mockedState,
-      );
-      const roleName = trixtaCommonSelectors.selectTrixtaRoleNameProp(
+      const hasAccess = trixtaCommonSelectors.selectTrixtaRoleAccessSelector(
         mockedState,
         props,
       );
-
-      const expectedResult = agentDetails.includes(roleName);
+      const expectedResult = hasAccess;
 
       expect(selector(mockedState, props)).toEqual(expectedResult);
       expect(expectedResult).toEqual(true);
     });
 
-    it('makeSelectHasTrixtaRoleAccessForRoles', () => {
+    it('makeSelectHasTrixtaRoleAccessForRole', () => {
       const trixtaRoles = [
         'guest[d1be63be-c0e4-4468-982c-5c04714a2987]',
         'host[d1be63be-c0e4-4468-982c-5c04714a2987]',
       ];
-      const props = { roles: trixtaRoles };
-      const selector = trixtaCommonSelectors.makeSelectHasTrixtaRoleAccessForRoles();
-      const agentRoles = trixtaCommonSelectors.selectTrixtaAgentDetails(
+      const props = { roleName: trixtaRoles[0] };
+      const selector = trixtaCommonSelectors.makeSelectHasTrixtaRoleAccessForRole();
+      const hasAccess = trixtaCommonSelectors.selectHasTrixtaRoleAccess(
         mockedState,
         props,
       );
-      const roles = trixtaCommonSelectors.selectTrixtaRolesProp(
-        mockedState,
-        props,
-      );
+
       let expectedResult = false;
-      if (isNullOrEmpty(roles)) expectedResult = false;
-      if (!Array.isArray(roles)) expectedResult = false;
-      expectedResult = roles.every((role) => agentRoles.includes(role));
+      expectedResult = hasAccess;
 
       expect(selector(mockedState, props)).toEqual(expectedResult);
       expect(expectedResult).toEqual(true);

--- a/src/React/types/common/index.ts
+++ b/src/React/types/common/index.ts
@@ -173,7 +173,7 @@ export type TrixtaState = {
   error: DefaultUnknownType;
   authorizationStarted: boolean;
   authorizingStatus: Record<string, LoadingStatus>;
-  agentDetails: string[];
+  agentDetails: Record<string, boolean>;
 };
 
 export interface TrixtaInstanceResponse<

--- a/src/stories/reduxStore/Preview.stories.mdx
+++ b/src/stories/reduxStore/Preview.stories.mdx
@@ -32,7 +32,7 @@ Below is a preview of the Trixta redux reducer and an explanation of each key
 
 ## agentDetails
 
-When a role for a given space is joined , each role will be in this array
+When a role for a given space is joined , each role will be keyed with 'roleName':true
 
 <Story name="Agent Details" args={{ section: 'agentDetails' }}>
   {Template.bind({})}


### PR DESCRIPTION


### What:
- trixta auth has been refactored to use a map instead of an array for roles

BREAKING CHANGE: useTrixtaAccess and useTrixtaAuth no longer use roles prop but roleName